### PR TITLE
parse instance properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,32 @@ Parse and validate Electron's markdown API documentation.
 npm install electron-docs-linter --save
 ```
 
-## Usage
+## CLI Usage
+
+If linting errors are found, they are printed to STDERR and the process
+exits un-gracefully.
+
+```sh
+electron-docs-linter docs/api
+```
+
+If you've piped the output, the JSON schema is written to that pipe. Note
+that a `version` must be specified when piping.
+
+```sh
+electron-docs-linter docs/api --version=1.2.3 > api.json
+```
+
+If no pipe is present, you just see a nice message.
+
+```sh
+electron-docs-linter docs/api
+
+Docs are good to go! 👍
+```
+
+
+## Programmatic Usage
 
 The module exports a function that parses markdown docs in a given directory,
 then returns a JSON representation of the docs.

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+const path = require('path')
+const sum = require('lodash.sum')
+const lint = require('.')
+const args = require('minimist')(process.argv.slice(2))
+const piping = !process.stdout.isTTY
+
+var docsPath = args._[0]
+var version = args.version
+
+// docsPath is required
+if (!docsPath) usage()
+
+// docsPath is relative to current working directory
+docsPath = path.join(process.cwd(), docsPath)
+
+// version is required if piping output
+if (piping && !version) usage()
+
+// Use a placeholder version if not piping output
+if (!version) version = '0.0.0'
+
+const spinner = require('ora')('Parsing electron documentation').start()
+
+lint(docsPath, version).then(function (apis) {
+  spinner.stop().clear()
+
+  if (apis.some(api => api.errors.length)) {
+    fail(apis)
+  }
+
+  if (piping) {
+    process.stdout.write(JSON.stringify(apis, null, 2))
+  } else {
+    console.log('Docs are good to go! 👍')
+  }
+
+  process.exit()
+})
+
+function usage () {
+  console.error(`
+Usage: electron-docs-linter <pathname>
+
+To save the parsed JSON schema:
+
+electron-docs-linter <pathname> --version=1.2.3 --outfile=electron.json
+`)
+  process.exit(1)
+}
+
+function fail (apis) {
+  if (apis.some(api => api.errors.length)) {
+    console.error('\n🙊  uh-oh! bad docs 🙈\n')
+    apis.forEach(api => {
+      if (api.errors.length) api.logErrors()
+    })
+
+    const errorCount = sum(apis.map(api => api.errors.length))
+    console.error(`
+${errorCount} error${errorCount === 1 ? '' : 's'} found`)
+    process.exit(1)
+  }
+}

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const fetchDocs = require('electron-docs')
 const promisify = require('pify')
 const semver = require('semver')
 const exists = require('path-exists').sync
+const keyedArray = require('keyed-array')
 
 function lint (path, targetVersion, callback) {
   if (typeof callback !== 'function') {
@@ -25,11 +26,11 @@ function lint (path, targetVersion, callback) {
         return new API(props, docs)
       })
 
-      // Attach named keys to the array for easier traversal of the object.
-      // e.g. apis.Tray, apis.BrowserWindow
-      apis.forEach(api => {
-        apis[api.name] = api
-      })
+      // Attach named keys to collection arrays for easier access
+      // apis.app.events.login
+      // apis.app.methods.quit
+      // apis.BrowserWindow.instanceMethods.isFocused
+      apis = keyedArray(apis)
 
       return callback(null, apis)
     })

--- a/lib/api.js
+++ b/lib/api.js
@@ -24,7 +24,8 @@ class API {
       {name: 'methods', selector: 'h2#methods', parser: 'methods'},
       {name: 'instanceMethods', selector: 'h2#instance-methods', parser: 'methods'},
       {name: 'events', selector: 'h2#events', parser: 'events'},
-      {name: 'instanceEvents', selector: 'h3#instance-events', parser: 'events'}
+      {name: 'instanceEvents', selector: 'h3#instance-events', parser: 'events'},
+      {name: 'instanceProperties', selector: 'h2#instance-properties', parser: 'properties'}
     ]
 
     collections.forEach(_ => {

--- a/lib/api.js
+++ b/lib/api.js
@@ -41,12 +41,27 @@ class API {
     return revalidator.validate(this, schema).errors
   }
 
-  addError (type, html) {
+  addError (type, pattern, html) {
     this.errors.push({
       type: type,
       filename: this.doc.filename,
+      pattern: pattern,
       html: html,
       markdownGuess: toMarkdown(html)
+    })
+  }
+
+  logErrors () {
+    if (!this.errors || !this.errors.length) return
+
+    this.errors.forEach(err => {
+      var {type, filename, pattern, html, markdownGuess} = err
+      console.error('-----------------------')
+      console.error(`file: ${filename}`)
+      console.error(`type: ${type}`)
+      console.error(`pattern: ${pattern}`)
+      console.error(`html: ${html}`)
+      console.error(`markdown (approximate): ${markdownGuess}`)
     })
   }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,7 +4,6 @@ const omitEmpty = require('omit-empty')
 const pick = require('lodash.pick')
 const toMarkdown = require('to-markdown')
 const revalidator = require('revalidator')
-const keyedArray = require('keyed-array')
 const schema = require('./api/schema')
 
 class API {
@@ -31,13 +30,6 @@ class API {
     collections.forEach(_ => {
       const {name, selector, parser} = _
       this[name] = require(`./api/${parser}`)(this, selector)
-
-      // Attach named keys to collection arrays for easier access
-      // Examples:
-      // apis.app.events.login
-      // apis.app.methods.quit
-      // apis.BrowserWindow.instanceMethods.isFocused
-      keyedArray.addKeys(this[name])
     })
   }
 

--- a/lib/api/events.js
+++ b/lib/api/events.js
@@ -3,14 +3,15 @@ const omitEmpty = require('omit-empty')
 module.exports = function (api, headingSelector) {
   var $ = api.$
   const helpers = require('../helpers')(api)
+  const pattern = /Event: '(.*)'/
 
   return $(headingSelector)
     .nextUntil('h2')
     .filter(helpers.h3orh4)
     .map((i, el) => {
-      var match = $(el).text().match(/Event: '(.*)'/)
+      var match = $(el).text().match(pattern)
 
-      if (!match) return api.addError('event', $(el).html())
+      if (!match) return api.addError('event', pattern, $(el).html())
 
       var event = {
         name: match[1],

--- a/lib/api/methods.js
+++ b/lib/api/methods.js
@@ -3,14 +3,15 @@ const omitEmpty = require('omit-empty')
 module.exports = function (api, headingSelector) {
   var $ = api.$
   const helpers = require('../helpers')(api)
+  const pattern = /.*\.(\w+)(.*)/
 
   return $(headingSelector)
     .nextUntil('h2')
     .filter(helpers.h3)
     .map((i, el) => {
-      var match = $(el).find('code').text().match(/.*\.(\w+)(.*)/)
+      var match = $(el).find('code').text().match(pattern)
 
-      if (!match) return api.addError('method', $(el).html())
+      if (!match) return api.addError('method', pattern, $(el).html())
 
       var method = {
         name: match[1],

--- a/lib/api/properties.js
+++ b/lib/api/properties.js
@@ -1,0 +1,22 @@
+const omitEmpty = require('omit-empty')
+
+module.exports = function (api, headingSelector) {
+  var $ = api.$
+  const helpers = require('../helpers')(api)
+
+  return $(headingSelector)
+    .nextUntil('h2')
+    .filter(helpers.h3)
+    .map((i, el) => {
+      var match = $(el).find('code').text().match(/.*\.(\w+)(.*)/)
+
+      if (!match) return api.addError('property', $(el).html())
+
+      var property = {
+        name: match[1],
+        description: $(el).getDescription()
+      }
+      return (omitEmpty(property))
+    })
+    .get()
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -30,7 +30,7 @@ module.exports = function (api) {
   }
 
   $.prototype.getArguments = function (api, type) {
-    const pattern = /<code>(\w+)<\/code>\s*(?:<a href.*>)?(\w+)(?:<\/a>)?(?: - )?(.*)$/
+    const pattern = /<code>(\w+)<\/code>\s*(?:<a href.*>)?([a-zA-Z0-9\[\]]+)(?:<\/a>)?(?: - )?(.*)/
 
     return this
       .nextUntil('h2,h3')
@@ -42,7 +42,7 @@ module.exports = function (api) {
           .match(pattern)
 
         // Parsing error
-        if (!match) return api.addError('arguments', $(el).html())
+        if (!match) return api.addError('arguments', pattern, $(el).html())
 
         // Preserve backticks
         var description = match[3].replace(/<\/?code>/g, '`')
@@ -62,8 +62,7 @@ module.exports = function (api) {
         // `theProp` String - Some description
         //
         // However, one place where event and function arguments differ is that
-        // arguments are sometimes required. Being `required` doesn't really
-        // apply to events. So...
+        // arguments are sometimes required.
         if (type !== 'event') {
           arg.required = !$(el).text().match('(optional)')
         }
@@ -72,7 +71,7 @@ module.exports = function (api) {
           .find('li')
           .map((i, el) => {
             var match = $(el).html().match(pattern)
-            if (!match) return api.addError('argument subproperties', $(el).html())
+            if (!match) return api.addError('argument subproperties', pattern, $(el).html())
             return {
               name: match[1],
               type: match[2],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-docs-linter",
   "description": "A JSON object describing Electron's APIs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)",
   "bugs": {
     "url": "https://github.com/zeke/electron-docs-linter/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-docs-linter",
   "description": "A JSON object describing Electron's APIs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)",
   "bugs": {
     "url": "https://github.com/zeke/electron-docs-linter/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-docs-linter",
   "description": "A JSON object describing Electron's APIs",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)",
   "bugs": {
     "url": "https://github.com/zeke/electron-docs-linter/issues"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
   "bugs": {
     "url": "https://github.com/zeke/electron-docs-linter/issues"
   },
+  "bin": "cli.js",
   "dependencies": {
     "decamelize": "^1.2.0",
     "electron-docs": "^1.1.0",
     "keyed-array": "^2.0.0",
     "lodash.pick": "^4.2.1",
+    "lodash.sum": "^4.0.2",
     "marky-markdown-lite": "^1.1.0",
+    "minimist": "^1.2.0",
     "omit-empty": "^0.4.1",
+    "ora": "^0.2.3",
     "pify": "^2.3.0",
     "revalidator": "^0.3.1",
     "to-markdown": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "decamelize": "^1.2.0",
     "electron-docs": "^1.1.0",
-    "keyed-array": "^1.0.0",
+    "keyed-array": "^2.0.0",
     "lodash.pick": "^4.2.1",
     "marky-markdown-lite": "^1.1.0",
     "omit-empty": "^0.4.1",
@@ -43,5 +43,8 @@
     "env": {
       "mocha": true
     }
+  },
+  "engines": {
+    "node": ">=4"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -105,6 +105,20 @@ describe('apis', function () {
     })
   })
 
+  describe('Instance Properties', function () {
+    they('exist on a number of APIs', function () {
+      expect(apis.Menu.instanceProperties).to.exist
+      expect(apis.webContents.instanceProperties).to.exist
+      expect(apis.BrowserWindow.instanceProperties).to.exist
+    })
+
+    they('exist on BrowserWindow', function () {
+      let {name, description} = apis.BrowserWindow.instanceProperties.webContents
+      expect(name).to.equal('webContents')
+      expect(description).to.include('The WebContents object this window owns')
+    })
+  })
+
   describe('Events', function () {
     it('is an array of event objects', function () {
       expect(apis.app.events.length).to.be.above(10)

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,8 @@ const they = it
 var apis
 
 describe('apis', function () {
+  this.timeout(10*1000)
+
   before(function (done) {
     var docPath = path.join(__dirname, '../vendor/electron/docs/api')
     lint(docPath, '1.2.3')

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ const they = it
 var apis
 
 describe('apis', function () {
-  this.timeout(10*1000)
+  this.timeout(10 * 1000)
 
   before(function (done) {
     var docPath = path.join(__dirname, '../vendor/electron/docs/api')
@@ -15,6 +15,9 @@ describe('apis', function () {
       .then(function (_apis) {
         apis = _apis
         done()
+      })
+      .catch(function (err) {
+        console.error(err)
       })
   })
 


### PR DESCRIPTION
@jlord and I paired on this today. It introduces a new parser for collecting instance properties

- [browser-window.md#instance-properties](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#instance-properties)
- [menu.md#instance-properties](https://github.com/electron/electron/blob/master/docs/api/menu.md#instance-properties)
- [web-contents.md#instance-properties](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#instance-properties)

Still "hashing" out the proper heading levels here: https://github.com/electron/electron/pull/6461

Fixes https://github.com/zeke/electron-docs-linter/issues/2