### PR TITLE
use keyedArray 2.0 with console.log overriding feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const fetchDocs = require('electron-docs')
 const promisify = require('pify')
 const semver = require('semver')
 const exists = require('path-exists').sync
+const keyedArray = require('keyed-array')
 
 function lint (path, targetVersion, callback) {
   if (typeof callback !== 'function') {
@@ -25,11 +26,11 @@ function lint (path, targetVersion, callback) {
         return new API(props, docs)
       })
 
-      // Attach named keys to the array for easier traversal of the object.
-      // e.g. apis.Tray, apis.BrowserWindow
-      apis.forEach(api => {
-        apis[api.name] = api
-      })
+      // Attach named keys to collection arrays for easier access
+      // apis.app.events.login
+      // apis.app.methods.quit
+      // apis.BrowserWindow.instanceMethods.isFocused
+      apis = keyedArray(apis)
 
       return callback(null, apis)
     })

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,7 +4,6 @@ const omitEmpty = require('omit-empty')
 const pick = require('lodash.pick')
 const toMarkdown = require('to-markdown')
 const revalidator = require('revalidator')
-const keyedArray = require('keyed-array')
 const schema = require('./api/schema')
 
 class API {
@@ -31,13 +30,6 @@ class API {
     collections.forEach(_ => {
       const {name, selector, parser} = _
       this[name] = require(`./api/${parser}`)(this, selector)
-
-      // Attach named keys to collection arrays for easier access
-      // Examples:
-      // apis.app.events.login
-      // apis.app.methods.quit
-      // apis.BrowserWindow.instanceMethods.isFocused
-      keyedArray.addKeys(this[name])
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "env": {
       "mocha": true
     }
+  },
+  "engines": {
+    "node": ">=4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "decamelize": "^1.2.0",
     "electron-docs": "^1.1.0",
-    "keyed-array": "^1.0.0",
+    "keyed-array": "^2.0.0",
     "lodash.pick": "^4.2.1",
     "marky-markdown-lite": "^1.1.0",
     "omit-empty": "^0.4.1",

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,8 @@ const they = it
 var apis
 
 describe('apis', function () {
+  this.timeout(10*1000)
+
   before(function (done) {
     var docPath = path.join(__dirname, '../vendor/electron/docs/api')
     lint(docPath, '1.2.3')


### PR DESCRIPTION
I figured out another piece of the [keyed array](https://github.com/zeke/keyed-array) puzzle. Node.js allows the `console.log` output of an object to be customized by overriding the object's `inspect` method.

This updated version of keyed-array [exploits the `inspect()` technique](https://github.com/zeke/keyed-array/blob/3dbc571e4ababab39ccfce5a74f98f6ba4ce62b0/index.js#L3-L15) to restore dignity to logged arrays:

### Old



```js
console.log(apis.webContents.instanceMethods.savePage.arguments)

[
  {
    name: 'fullPath',
    type: 'String',
    description: 'The full file path.',
    required: true
  }, {
    name: 'saveType',
    type: 'String',
    description: 'Specify the save type.',
    required: true
  },
  fullPath: {
    name: 'fullPath',
    type: 'String',
    description: 'The full file path.',
    required: true
  },
  saveType: {
    name: 'saveType',
    type: 'String',
    description: 'Specify the save type.',
    required: true
  }
]
```

### New

```js
console.log(apis.webContents.instanceMethods.savePage.arguments)

[
  {
    name: 'fullPath',
    type: 'String',
    description: 'The full file path.',
    required: true
  }, {
    name: 'saveType',
    type: 'String',
    description: 'Specify the save type.',
    required: true
  }
]
```

cc @jlord